### PR TITLE
fix: Trigger API deployment on BCD release

### DIFF
--- a/.github/workflows/deploy-prod-api.yml
+++ b/.github/workflows/deploy-prod-api.yml
@@ -15,6 +15,8 @@ on:
         required: true
       WIP_PROJECT_ID:
         required: true
+  repository_dispatch:
+    types: [bcd_release]
 
 jobs:
   deploy-prod-api:


### PR DESCRIPTION
- Fixes https://github.com/mdn/bcd-utils/issues/23

- Other half of the fix is https://github.com/mdn/browser-compat-data/pull/20561

As this will run the workflow after BCD is published to NPM, can the daily cron setting `cron: "0 0 * * *"` be removed to save resources?
Should we do the same in deploy-prod-updates.yml workflow?